### PR TITLE
Python3 support

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -692,7 +692,7 @@ class Tool:
   def __init__(self, data):
     # Convert the dictionary representation of the tool in 'data' to members of this class for convenience.
     for key in data:
-      if sys.version_info < (3,) and isinstance(data[key], str):
+      if sys.version_info < (3,) and isinstance(data[key], unicode):
         setattr(self, key, data[key].encode('Latin-1'))
       else:
         setattr(self, key, data[key])

--- a/emsdk
+++ b/emsdk
@@ -313,7 +313,7 @@ def download_text_file(url, dstpath, download_even_if_exists=False):
   fix_lineendings(os.path.join(emsdk_path(), filename))
 
 def run_get_output(cmd, cwd=None):
-  process = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, env=os.environ.copy())
+  process = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, env=os.environ.copy(), universal_newlines=True)
   (stdout, stderr) = process.communicate()
   return (process.returncode, stdout, stderr)
 
@@ -692,7 +692,7 @@ class Tool:
   def __init__(self, data):
     # Convert the dictionary representation of the tool in 'data' to members of this class for convenience.
     for key in data:
-      if isinstance(data[key], str):
+      if sys.version_info < (3,) and isinstance(data[key], str):
         setattr(self, key, data[key].encode('Latin-1'))
       else:
         setattr(self, key, data[key])

--- a/emsdk
+++ b/emsdk
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 
-import sys, optparse, subprocess, urllib2, os, os.path, errno, zipfile, string, json, platform, shutil, tarfile, urlparse, tempfile, multiprocessing
+from __future__ import print_function
+import sys, optparse, subprocess, os, os.path, errno, zipfile, string, json, platform, shutil, tarfile, tempfile, multiprocessing
+if sys.version_info >= (3,):
+  from urllib.parse import urljoin
+  from urllib.request import urlopen
+  from urllib.error import HTTPError
+else:
+  from urlparse import urljoin
+  from urllib2 import urlopen, HTTPError
 
 # EMSDK_DEV is a developer mode flag, which, if true, the SDK is downloaded from a 'staging' online source,
 # instead of the public source. New releases are first deployed to the staging source for testing, before 
@@ -9,12 +17,12 @@ import sys, optparse, subprocess, urllib2, os, os.path, errno, zipfile, string, 
 EMSDK_DEV = bool(os.getenv('EMSDK_DEV')) if os.getenv('EMSDK_DEV') != None else False
 
 if EMSDK_DEV:
-  print 'EMSDK_DEV active.'
+  print('EMSDK_DEV active.')
   emsdk_master_server = 'http://clb.demon.fi/emscripten_dev/'
 else:
   emsdk_master_server = 'https://s3.amazonaws.com/mozilla-games/emscripten/'
 
-emsdk_packages_url = urlparse.urljoin(emsdk_master_server, 'packages/')
+emsdk_packages_url = urljoin(emsdk_master_server, 'packages/')
 
 emscripten_git_repo = 'git@github.com:kripken/emscripten.git'
 
@@ -58,10 +66,10 @@ def win_get_environment_variable(key, system=True):
     else: # Register locally from CURRENT USER section.
       folder = win32api.RegOpenKey(win32con.HKEY_CURRENT_USER, 'Environment')
     value = str(win32api.RegQueryValueEx(folder, key)[0])
-  except Exception, e:
+  except Exception as e:
     if e[0] != 2: # 'The system cannot find the file specified.'
-      print >> sys.stderr, 'Failed to read environment variable ' + key + ':'
-      print >> sys.stderr, str(e)
+      print('Failed to read environment variable ' + key + ':', file=sys.stderr)
+      print(str(e), file=sys.stderr)
     win32api.RegCloseKey(folder)
     os.environ['PATH'] = prev_path
     return None
@@ -91,7 +99,7 @@ def win_set_environment_variable(key, value, system=True):
         value = subprocess.call(['REG', 'DELETE', 'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment', '/V', key, '/f'], stdout=subprocess.PIPE)
       else:
         value = subprocess.call(['REG', 'DELETE', 'HKCU\\Environment', '/V', key, '/f'], stdout=subprocess.PIPE)
-    except Exception, e:
+    except Exception as e:
       return
     return
 
@@ -102,11 +110,11 @@ def win_set_environment_variable(key, value, system=True):
       cmd = ['SETX']
     retcode = subprocess.call(cmd + [key, value], stdout=subprocess.PIPE)
     if retcode is not 0:
-      print >> sys.stderr, 'ERROR! Failed to set environment variable ' + key + '=' + value + '. You may need to set it manually.'
-  except Exception, e:
-    print >> sys.stderr, 'ERROR! Failed to set environment variable ' + key + '=' + value + ':'
-    print >> sys.stderr, str(e)
-    print >> sys.stderr, 'You may need to set it manually.'
+      print('ERROR! Failed to set environment variable ' + key + '=' + value + '. You may need to set it manually.', file=sys.stderr)
+  except Exception as e:
+    print('ERROR! Failed to set environment variable ' + key + '=' + value + ':', file=sys.stderr)
+    print(str(e), file=sys.stderr)
+    print('You may need to set it manually.', file=sys.stderr)
 
 def win_delete_environment_variable(key, system=True):
   win_set_environment_variable(key, None, system)
@@ -165,15 +173,15 @@ def run(cmd, cwd=None):
   process = subprocess.Popen(cmd, cwd=cwd, env=os.environ.copy())
   process.communicate()
   if process.returncode != 0:
-    print str(cmd) + ' failed with error code ' + str(process.returncode) + '!'
+    print(str(cmd) + ' failed with error code ' + str(process.returncode) + '!')
   return process.returncode
 
 # http://pythonicprose.blogspot.fi/2009/10/python-extract-targz-archive.html
 def untargz(source_filename, dest_dir, unpack_even_if_exists=False):
   if not unpack_even_if_exists and num_files_in_directory(dest_dir) > 0:
-    print "File '" + source_filename + "' has already been unpacked, skipping."
+    print("File '" + source_filename + "' has already been unpacked, skipping.")
     return True
-  print "Unpacking '" + source_filename + "' to '" + dest_dir + "'"
+  print("Unpacking '" + source_filename + "' to '" + dest_dir + "'")
   mkdir_p(dest_dir)
   run(['tar', '-xvf', sdk_path(source_filename), '--strip', '1'], cwd=dest_dir)
   #tfile = tarfile.open(source_filename, 'r:gz')
@@ -183,9 +191,9 @@ def untargz(source_filename, dest_dir, unpack_even_if_exists=False):
 # http://stackoverflow.com/questions/12886768/simple-way-to-unzip-file-in-python-on-all-oses
 def unzip(source_filename, dest_dir, unpack_even_if_exists=False):
   if not unpack_even_if_exists and num_files_in_directory(dest_dir) > 0:
-    print "File '" + source_filename + "' has already been unpacked, skipping."
+    print("File '" + source_filename + "' has already been unpacked, skipping.")
     return True
-  print "Unpacking '" + source_filename + "' to '" + dest_dir + "'"
+  print("Unpacking '" + source_filename + "' to '" + dest_dir + "'")
   mkdir_p(dest_dir)
   common_subdir = None
   try:
@@ -229,12 +237,12 @@ def unzip(source_filename, dest_dir, unpack_even_if_exists=False):
           shutil.rmtree(unzip_to_dir)
         except:
           pass
-  except zipfile.BadZipfile, e:
-    print "Unzipping file '" + source_filename + "' failed due to reason: " + str(e) + "! Removing the corrupted zip file."
+  except zipfile.BadZipfile as e:
+    print("Unzipping file '" + source_filename + "' failed due to reason: " + str(e) + "! Removing the corrupted zip file.")
     rmfile(source_filename)
     return False
-  except Exception, e:
-    print "Unzipping file '" + source_filename + "' failed due to reason: " + str(e)
+  except Exception as e:
+    print("Unzipping file '" + source_filename + "' failed due to reason: " + str(e))
     return False
 
   return True
@@ -268,15 +276,15 @@ def download_file(url, dstpath, download_even_if_exists=False):
   file_name = sdk_path(file_name)
 
   if os.path.exists(file_name) and not download_even_if_exists:
-    print "File '" + file_name + "' already downloaded, skipping."
+    print("File '" + file_name + "' already downloaded, skipping.")
     return file_name
   try:
-    u = urllib2.urlopen(url)
+    u = urlopen(url)
     mkdir_p(os.path.dirname(file_name))
     with open(file_name, 'wb') as f: 
       meta = u.info()
       file_size = int(meta.getheaders("Content-Length")[0])
-      print "Downloading: %s from %s Bytes: %s" % (file_name, url, file_size)
+      print("Downloading: %s from %s Bytes: %s" % (file_name, url, file_size))
 
       file_size_dl = 0
       block_sz = 8192
@@ -289,13 +297,13 @@ def download_file(url, dstpath, download_even_if_exists=False):
           f.write(buffer)
           status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
           status = status + chr(8)*(len(status)+1)
-          print status,
-  except urllib2.HTTPError, e:
-    print "HTTP error with URL '" + url + "': " + str(e)
+          print(status, end=' ')
+  except HTTPError as e:
+    print("HTTP error with URL '" + url + "': " + str(e))
     rmfile(file_name)
     return None
-  except Exception, e:
-    print "Error downloading URL '" + url + "': " + str(e)
+  except Exception as e:
+    print("Error downloading URL '" + url + "': " + str(e))
     rmfile(file_name)
     return None
   return file_name
@@ -350,13 +358,13 @@ def GIT(must_succeed=True):
       pass
   if must_succeed:
     if WINDOWS:
-      print "ERROR: git executable was not found. Please install it by typing 'emsdk install git-1.9.4', or alternatively by installing it manually from http://git-scm.com/downloads . If you install git manually, remember to add it to PATH"
+      print("ERROR: git executable was not found. Please install it by typing 'emsdk install git-1.9.4', or alternatively by installing it manually from http://git-scm.com/downloads . If you install git manually, remember to add it to PATH")
     elif OSX:
-      print "ERROR: git executable was not found. Please install git for this operation! This can be done from http://git-scm.com/ , or by installing XCode and then the XCode Command Line Tools (see http://stackoverflow.com/questions/9329243/xcode-4-4-command-line-tools )"
+      print("ERROR: git executable was not found. Please install git for this operation! This can be done from http://git-scm.com/ , or by installing XCode and then the XCode Command Line Tools (see http://stackoverflow.com/questions/9329243/xcode-4-4-command-line-tools )")
     elif LINUX:
-      print "ERROR: git executable was not found. Please install git for this operation! This can be probably be done using your package manager, see http://git-scm.com/book/en/Getting-Started-Installing-Git"
+      print("ERROR: git executable was not found. Please install git for this operation! This can be probably be done using your package manager, see http://git-scm.com/book/en/Getting-Started-Installing-Git")
     else:
-      print "ERROR: git executable was not found. Please install git for this operation!"
+      print("ERROR: git executable was not found. Please install git for this operation!")
     sys.exit(1)
   return '' # Not found
 
@@ -369,7 +377,7 @@ def git_repo_version(repo_path):
 
 def git_clone(url, dstpath):
   if os.path.isdir(os.path.join(dstpath, '.git')):
-    print "Repository '" + url + "' already cloned to directory '" + dstpath + "', skipping."
+    print("Repository '" + url + "' already cloned to directory '" + dstpath + "', skipping.")
     return True
   mkdir_p(dstpath)
   return run([GIT(), 'clone', url, dstpath]) == 0
@@ -377,16 +385,16 @@ def git_clone(url, dstpath):
 def git_checkout_and_pull(repo_path, branch):
   run([GIT(), 'fetch', 'origin'], repo_path)
   try:
-    print "Fetching latest changes to the branch '" + branch + "' for '" + repo_path + "'..."
+    print("Fetching latest changes to the branch '" + branch + "' for '" + repo_path + "'...")
     run([GIT(), 'fetch', 'origin'], repo_path)
 #  run([GIT, 'checkout', '-b', branch, '--track', 'origin/'+branch], repo_path)
     run([GIT(), 'checkout', '--quiet', branch], repo_path) # this line assumes that the user has not gone and manually messed with the repo and added new remotes to ambiguate the checkout.
     run([GIT(), 'merge', '--ff-only', 'origin/'+branch], repo_path) # this line assumes that the user has not gone and made local changes to the repo
   except:
-    print 'git operation failed!'
+    print('git operation failed!')
     return False
-  print "Successfully updated and checked out branch '" + branch + "' on repository '" + repo_path + "'"
-  print "Current repository version: " + git_repo_version(repo_path)
+  print("Successfully updated and checked out branch '" + branch + "' on repository '" + repo_path + "'")
+  print("Current repository version: " + git_repo_version(repo_path))
   return True
 
 def git_clone_checkout_and_pull(url, dstpath, branch):
@@ -443,9 +451,9 @@ def find_msbuild(sln_file):
 def make_build(build_root, build_type):
   cpu_cores = max(multiprocessing.cpu_count()-1, 1) # Don't saturate all cores to not steal the whole system, but be aggressive.
   if cpu_cores > 1:
-    print 'Performing a parallel build with ' + str(cpu_cores) + ' cores.'
+    print('Performing a parallel build with ' + str(cpu_cores) + ' cores.')
   else:
-    print 'Performing a singlethreaded build.'
+    print('Performing a singlethreaded build.')
   if WINDOWS:
     if 'Visual Studio' in CMAKE_GENERATOR:
       solution_name = subprocess.check_output(['dir', '/b', '*.sln'], shell=True, cwd=build_root).strip()
@@ -457,16 +465,16 @@ def make_build(build_root, build_type):
 
   # Build
   try:
-    print 'Running build: ' + str(make)
+    print('Running build: ' + str(make))
     ret = subprocess.check_call(make, cwd=build_root, env=make_env)
     if ret != 0:
-      print >> sys.stderr, 'Build failed with exit code ' + ret + '!'
-      print >> sys.stderr, 'Working directory: ' + build_root
+      print('Build failed with exit code ' + ret + '!', file=sys.stderr)
+      print('Working directory: ' + build_root, file=sys.stderr)
       return False
-  except Exception, e:
-    print >> sys.stderr, 'Build failed due to exception!'
-    print >> sys.stderr, 'Working directory: ' + build_root
-    print >> sys.stderr, str(e)
+  except Exception as e:
+    print('Build failed due to exception!', file=sys.stderr)
+    print('Working directory: ' + build_root, file=sys.stderr)
+    print(str(e), file=sys.stderr)
     return False
 
   return True
@@ -478,28 +486,28 @@ def cmake_configure(generator, build_root, src_root, build_type, extra_cmake_arg
     if generator: generator = ['-G', generator]
     else: generator = []
     cmdline = ['cmake'] + generator +  ['-DCMAKE_BUILD_TYPE='+build_type] + extra_cmake_args + [src_root]
-    print 'Running CMake: ' + str(cmdline)
+    print('Running CMake: ' + str(cmdline))
     ret = subprocess.check_call(cmdline, cwd=build_root)
     if ret != 0:
-      print >> sys.stderr, 'CMake invocation failed with exit code ' + ret + '!'
-      print >> sys.stderr, 'Working directory: ' + build_root
+      print('CMake invocation failed with exit code ' + ret + '!', file=sys.stderr)
+      print('Working directory: ' + build_root, file=sys.stderr)
       return False  
-  except OSError, e:
+  except OSError as e:
     if e.errno == errno.ENOENT:
-      print >> sys.stderr, str(e)
-      print >> sys.stderr, 'Could not run CMake, perhaps it has not been installed?'
+      print(str(e), file=sys.stderr)
+      print('Could not run CMake, perhaps it has not been installed?', file=sys.stderr)
       if WINDOWS:
-        print >> sys.stderr, 'Installing this package requires CMake. Get it from http://www.cmake.org/'
+        print('Installing this package requires CMake. Get it from http://www.cmake.org/', file=sys.stderr)
       elif LINUX:
-        print >> sys.stderr, 'Installing this package requires CMake. Get it via your system package manager (e.g. sudo apt-get install cmake), or from http://www.cmake.org/'
+        print('Installing this package requires CMake. Get it via your system package manager (e.g. sudo apt-get install cmake), or from http://www.cmake.org/', file=sys.stderr)
       elif OSX:
-        print >> sys.stderr, 'Installing this package requires CMake. Get it via a OSX package manager (Homebrew: "brew install cmake", or MacPorts: "sudo port install cmake"), or from http://www.cmake.org/'        
+        print('Installing this package requires CMake. Get it via a OSX package manager (Homebrew: "brew install cmake", or MacPorts: "sudo port install cmake"), or from http://www.cmake.org/', file=sys.stderr)        
       return False
     raise
-  except Exception, e:
-    print >> sys.stderr, 'CMake invocation failed due to exception!'
-    print >> sys.stderr, 'Working directory: ' + build_root
-    print >> sys.stderr, str(e)
+  except Exception as e:
+    print('CMake invocation failed due to exception!', file=sys.stderr)
+    print('Working directory: ' + build_root, file=sys.stderr)
+    print(str(e), file=sys.stderr)
     return False
 
   return True
@@ -546,9 +554,9 @@ def build_optimizer_tool(tool):
 
 def download_and_unzip(zipfile, dest_dir, download_even_if_exists=False):
   if not download_even_if_exists and num_files_in_directory(dest_dir) > 0:
-    print "The contents of file '" + zipfile + "' already exist in destination '" + dest_dir + "', skipping."
+    print("The contents of file '" + zipfile + "' already exist in destination '" + dest_dir + "', skipping.")
     return True
-  dst_file = download_file(urlparse.urljoin(emsdk_packages_url, zipfile), 'zips/', download_even_if_exists)
+  dst_file = download_file(urljoin(emsdk_packages_url, zipfile), 'zips/', download_even_if_exists)
   if not dst_file:
     return False
   if zipfile.endswith('.zip'):
@@ -642,19 +650,19 @@ JS_ENGINES = [NODE_JS]
   except:
     pass
 
-  print "The Emscripten configuration file " + os.path.normpath(dot_emscripten_path()) + " has been rewritten with the following contents:"
-  print ''
-  print cfg.strip()
-  print ''
+  print("The Emscripten configuration file " + os.path.normpath(dot_emscripten_path()) + " has been rewritten with the following contents:")
+  print('')
+  print(cfg.strip())
+  print('')
   
   path_add = get_required_path(active_tools)
   if not WINDOWS:
     emsdk_env = os.path.relpath(sdk_path('emsdk_env.sh'))
     if not '/' in emsdk_env:
       emsdk_env = './emsdk_env.sh'
-    print "To conveniently access the selected set of tools from the command line, consider adding the following directories to PATH, or call 'source " + emsdk_env + "' to do this for you."
-    print ''
-    print '   ' + ENVPATH_SEPARATOR.join(path_add)
+    print("To conveniently access the selected set of tools from the command line, consider adding the following directories to PATH, or call 'source " + emsdk_env + "' to do this for you.")
+    print('')
+    print('   ' + ENVPATH_SEPARATOR.join(path_add))
 
 def find_msbuild_dir():
   if 'ProgramFiles' in os.environ and os.environ['ProgramFiles']:
@@ -684,7 +692,7 @@ class Tool:
   def __init__(self, data):
     # Convert the dictionary representation of the tool in 'data' to members of this class for convenience.
     for key in data:
-      if isinstance(data[key], unicode):
+      if isinstance(data[key], str):
         setattr(self, key, data[key].encode('Latin-1'))
       else:
         setattr(self, key, data[key])
@@ -772,7 +780,7 @@ class Tool:
       for tool_name in self.uses:
         tool = find_tool(tool_name)
         if tool == None:
-          print "Manifest error: No tool by name '" + tool_name + "' found! This may indicate an internal SDK error!"
+          print("Manifest error: No tool by name '" + tool_name + "' found! This may indicate an internal SDK error!")
           return False
         if not tool.is_installed():
           return False
@@ -820,7 +828,7 @@ class Tool:
 #      print 'activated cfg ' + key + ', value: ' + value
 #      if dot_emscripten.has_key(key):
 #        print 'dot_emscripten ' + dot_emscripten[key]
-      if dot_emscripten.has_key(key) and dot_emscripten[key] != value:
+      if key in dot_emscripten and dot_emscripten[key] != value:
         return False
     return True
 
@@ -877,19 +885,19 @@ class Tool:
 
   def install(self):
     if self.can_be_installed() != True:
-      print "The tool '" + str(self) + "' is not available due to the reason: " + self.can_be_installed()
+      print("The tool '" + str(self) + "' is not available due to the reason: " + self.can_be_installed())
       return False
 
-    print "Installing '" + str(self) + "'.."
+    print("Installing '" + str(self) + "'..")
     if self.id == 'sdk':
       for tool_name in self.uses:
         tool = find_tool(tool_name)
         if tool == None:
-          print "Manifest error: No tool by name '" + tool_name + "' found! This may indicate an internal SDK error!"
+          print("Manifest error: No tool by name '" + tool_name + "' found! This may indicate an internal SDK error!")
         success = tool.install()
         if not success:
           return False
-        print "Done."
+        print("Done.")
       return True
     else:
       url = self.download_url()
@@ -904,21 +912,21 @@ class Tool:
         download_even_if_exists = (self.id == 'vs-tool')
         success = download_and_unzip(url, self.installation_path(), download_even_if_exists)
       else:
-        dst_file = download_file(urlparse.urljoin(emsdk_packages_url, self.download_url()), self.installation_path())
+        dst_file = download_file(urljoin(emsdk_packages_url, self.download_url()), self.installation_path())
         if dst_file:
           success = True
         else:
           success = False
       if not success:
-        print "Installation failed!"
+        print("Installation failed!")
         return False
-    print "Done."
+    print("Done.")
 
     # Sanity check that the installation succeeded, and if so, remove unneeded leftover installation files.
     if self.is_installed():
       self.cleanup_temp_install_files()
     else:
-      print "Warning: The installation of '" + str(self) + "' seems to have failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error."
+      print("Warning: The installation of '" + str(self) + "' seems to have failed, but no error was detected. Either something went wrong with the installation, or this may indicate an internal emsdk error.")
     return True
 
   def cleanup_temp_install_files(self):
@@ -930,16 +938,16 @@ class Tool:
 
   def uninstall(self):
     if  not self.is_installed():
-      print "Tool '" + str(self) + "' was not installed. No need to uninstall."
+      print("Tool '" + str(self) + "' was not installed. No need to uninstall.")
       return
-    print "Uninstalling tool '" + str(self) + "'.."
+    print("Uninstalling tool '" + str(self) + "'..")
     try:
-      print "Deleting path '" + self.installation_path() + "'"
+      print("Deleting path '" + self.installation_path() + "'")
       shutil.rmtree(self.installation_path(), ignore_errors=True)
       os.remove(self.installation_path())
     except:
       pass
-    print "Done."
+    print("Done.")
 
   def dependencies(self):
     if not hasattr(self, 'uses'):
@@ -1019,21 +1027,21 @@ def find_used_python():
 
 def update_emsdk():
   if WINDOWS:
-    download_and_unzip(urlparse.urljoin(emsdk_packages_url, 'emsdk_windows_update.zip'), emsdk_path(), download_even_if_exists=True)
+    download_and_unzip(urljoin(emsdk_packages_url, 'emsdk_windows_update.zip'), emsdk_path(), download_even_if_exists=True)
     rmfile('zips/emsdk_windows_update.zip')
   elif OSX or LINUX:
-    download_and_unzip(urlparse.urljoin(emsdk_packages_url, 'emsdk_unix_update.tar.gz'), emsdk_path(), download_even_if_exists=True)
+    download_and_unzip(urljoin(emsdk_packages_url, 'emsdk_unix_update.tar.gz'), emsdk_path(), download_even_if_exists=True)
     rmfile('zips/emsdk_unix_update.tar.gz')
   else:
-    print 'Unsupported OS, cannot update!'
+    print('Unsupported OS, cannot update!')
 
 def load_sdk_manifest():
   global tools
   try:
     manifest = json.loads(open(sdk_path("emsdk_manifest.json"), "r").read())
-  except Exception, e:
-    print 'Error parsing emsdk_manifest.json!'
-    print str(e)
+  except Exception as e:
+    print('Error parsing emsdk_manifest.json!')
+    print(str(e))
     return
   for tool in manifest['tools']:
     t = Tool(tool)
@@ -1062,7 +1070,7 @@ def remove_nonexisting_tools(tool_list, log_errors=True):
     tool = tool_list[i]
     if not tool.is_installed():
       if log_errors:
-        print "The SDK/tool '" + str(tool) + "' cannot be activated since it is not installed! Skipping this tool..."
+        print("The SDK/tool '" + str(tool) + "' cannot be activated since it is not installed! Skipping this tool...")
       tool_list.pop(i)
       continue
     i += 1
@@ -1119,7 +1127,7 @@ def set_active_tools(tools_to_activate, permanently_activate):
       if len(newpath) < 1024:
         win_set_environment_variable('PATH', newpath, system=True)
       else:
-        print >> sys.stderr, 'ERROR! The new PATH is more than 1024 characters long! A PATH this long cannot be set via command line: please add the PATHs specified above to system PATH manually via Control Panel.'
+        print('ERROR! The new PATH is more than 1024 characters long! A PATH this long cannot be set via command line: please add the PATHs specified above to system PATH manually via Control Panel.', file=sys.stderr)
 
   return tools_to_activate
 
@@ -1180,10 +1188,10 @@ def construct_env_windows(tools_to_activate, permanent):
   if os.environ['PATH'] != newpath: # Don't bother setting the path if there are no changes.
     env_string += 'SET PATH=' + newpath + '\n'
     if len(added_path) > 0:
-      print 'Adding directories to PATH:'
+      print('Adding directories to PATH:')
       for item in added_path:
-        print 'PATH += ' + item
-      print ''
+        print('PATH += ' + item)
+      print('')
 
   env_vars_to_add = []
   em_config_path = os.path.normpath(os.path.join(emscripten_config_directory, '.emscripten'))
@@ -1203,14 +1211,14 @@ def construct_env_windows(tools_to_activate, permanent):
         env_vars_to_add += [(key, value)]
 
   if len(env_vars_to_add) > 0:
-    print 'Setting environment variables:'
+    print('Setting environment variables:')
     for key, value in env_vars_to_add:
       if permanent:
         env_string += 'SETX ' + key + ' "' + value + '"\n'
       else:
         env_string += 'SET ' + key + '=' + value + '\n'
-      print key + ' = ' + value
-    print ''
+      print(key + ' = ' + value)
+    print('')
   return env_string
 
 def construct_env_unix(tools_to_activate):
@@ -1220,10 +1228,10 @@ def construct_env_unix(tools_to_activate):
   if os.environ['PATH'] != newpath: # Don't bother setting the path if there are no changes.
     env_string += 'export PATH="' + newpath + '"\n'
     if len(added_path) > 0:
-      print 'Adding directories to PATH:'
+      print('Adding directories to PATH:')
       for item in added_path:
-        print 'PATH += ' + item
-      print ''
+        print('PATH += ' + item)
+      print('')
 
   env_vars_to_add = []
   for tool in tools_to_activate:
@@ -1234,11 +1242,11 @@ def construct_env_unix(tools_to_activate):
         env_vars_to_add += [(key, value)]
 
   if len(env_vars_to_add) > 0:
-    print 'Setting environment variables:'
+    print('Setting environment variables:')
     for key, value in env_vars_to_add:
       env_string += 'export ' + key + '="' + value + '"\n'
-      print key + ' = ' + value
-    print ''
+      print(key + ' = ' + value)
+    print('')
   return env_string
 
 
@@ -1251,7 +1259,7 @@ def construct_env(tools_to_activate, permanent):
 def silentremove(filename):
   try:
     os.remove(filename)
-  except OSError, e:
+  except OSError as e:
     if e.errno != errno.ENOENT: raise
 
 def main():
@@ -1265,11 +1273,11 @@ def main():
 #  (options, args) = parser.parse_args(sys.argv)
   if len(sys.argv) <= 1 or sys.argv[1] == 'help':
     if len(sys.argv) <= 1:
-      print ' emsdk: No command given. Please call one of the following:'
+      print(' emsdk: No command given. Please call one of the following:')
     else:
-      print ' emsdk: Available commands:'
+      print(' emsdk: Available commands:')
 
-    print '''
+    print('''
    emsdk list [--old]           - Lists all available SDKs and tools and their
                                   current installation status. With the --old
                                   parameter, also historical versions are shown.
@@ -1281,10 +1289,10 @@ def main():
    emsdk uninstall <tool/sdk>   - Removes the given tool or SDK from disk.
 
    emsdk activate <tool/sdk>    - Activates the given tool or SDK in the
-                                  environment of the current shell.'''
+                                  environment of the current shell.''')
 
     if WINDOWS:
-      print '''
+      print('''
    emsdk activate [--global] [--embedded] <tool/sdk> 
 
                                 - Activates the given tool or SDK in
@@ -1299,9 +1307,9 @@ def main():
                                   directory rather than the user home directory.
 
    emcmdprompt.bat              - Spawns a new command prompt window with the
-                                  Emscripten environment active.'''
+                                  Emscripten environment active.''')
     else:
-      print '''
+      print('''
    emsdk activate [--embedded] <tool/sdk>
 
                                 - Activates the given tool or SDK in the
@@ -1310,7 +1318,7 @@ def main():
                                   configuration files as well as the temp, cache
                                   and ports directories are located inside the
                                   Emscripten SDK directory rather than the user
-                                  home directory.'''
+                                  home directory.''')
 
     return 1
   cmd = sys.argv[1]
@@ -1324,11 +1332,11 @@ def main():
       sys.argv[2] = str(find_latest_64bit_sdk())
 
   if cmd == 'list':
-    print ''
+    print('')
     show_old = len(sys.argv) >= 3 and sys.argv[2] == '--old'
     has_partially_active_tools = False
     if len(tools) > 0:
-      print 'The following individual tools exist:'
+      print('The following individual tools exist:')
       for tool in tools:
         if tool.is_old and not show_old:
           continue
@@ -1343,28 +1351,28 @@ def main():
           active = '(*)'
           has_partially_active_tools = True
         else: active = '   '
-        print '    ' + active + '    {0: <25}'.format(str(tool)) + installed
-      print ''
+        print('    ' + active + '    {0: <25}'.format(str(tool)) + installed)
+      print('')
     else:
-      print "There are no tools available. Run 'emsdk update' to fetch the latest set of tools."
-    print ''
+      print("There are no tools available. Run 'emsdk update' to fetch the latest set of tools.")
+    print('')
 
     if len(sdks) > 0:
-      print 'The following Emscripten SDK versions are available:'
+      print('The following Emscripten SDK versions are available:')
       for sdk in sdks:
         if sdk.is_old and not show_old:
           continue
         installed = '\tINSTALLED' if sdk.is_installed() else ''
         active = '*' if sdk.is_active() else ' '
-        print '    ' + active + '    {0: <25}'.format(str(sdk)) + installed
-      print ''
-      print 'Items marked with * are activated for the current user.'
+        print('    ' + active + '    {0: <25}'.format(str(sdk)) + installed)
+      print('')
+      print('Items marked with * are activated for the current user.')
       if has_partially_active_tools:
         env_cmd = 'emsdk_env.bat' if WINDOWS else 'source ./emsdk_env.sh'
-        print 'Items marked with (*) are selected for use, but your current shell environment is not configured to use them. Type "' + env_cmd + '" to set up your current shell to use them, or call "emsdk activate --global <name_of_sdk>" to permanently activate them.'
+        print('Items marked with (*) are selected for use, but your current shell environment is not configured to use them. Type "' + env_cmd + '" to set up your current shell to use them, or call "emsdk activate --global <name_of_sdk>" to permanently activate them.')
       if not show_old:
-        print ''
-        print "To access the historical archived versions, type 'emsdk list --old'"
+        print('')
+        print("To access the historical archived versions, type 'emsdk list --old'")
 
     return 0
   elif cmd == 'construct_env':
@@ -1377,7 +1385,7 @@ def main():
     tools_to_activate = process_tool_list(tools_to_activate, log_errors=True)
     env_string = construct_env(tools_to_activate, len(sys.argv) >= 3 and 'perm' in sys.argv[2])
     open(EMSDK_SET_ENV, 'w').write(env_string)
-    if LINUX or OSX: os.chmod(EMSDK_SET_ENV, 0755)
+    if LINUX or OSX: os.chmod(EMSDK_SET_ENV, 0o755)
     return 0
   elif cmd == 'update':
     update_emsdk()
@@ -1386,22 +1394,22 @@ def main():
   elif cmd == 'activate':
     permanently_activate = '--global' in sys.argv
     if permanently_activate:
-      print 'Registering active Emscripten environment globally for all users.'
-      print ''
+      print('Registering active Emscripten environment globally for all users.')
+      print('')
     embed_activation_to_sdk_dir = '--embedded' in sys.argv
     if embed_activation_to_sdk_dir:
       # Activating the emsdk tools locally relative to Emscripten SDK directory.
       emscripten_config_directory = emsdk_path()
-      print 'Writing .emscripten configuration file to Emscripten SDK directory ' + emscripten_config_directory
+      print('Writing .emscripten configuration file to Emscripten SDK directory ' + emscripten_config_directory)
     else:
-      print 'Writing .emscripten configuration file to user home directory ' + emscripten_config_directory
+      print('Writing .emscripten configuration file to user home directory ' + emscripten_config_directory)
       # Remove .emscripten from emsdk dir, since its presence is used to detect whether emsdk is activate in embedded mode or not.
       try:
         os.remove(os.path.join(emsdk_path(), ".emscripten"))
       except:
         pass
 
-    sys.argv = filter(lambda x: not x.startswith('--'), sys.argv)
+    sys.argv = [x for x in sys.argv if not x.startswith('--')]
     # If called without arguments, activate latest versions of all tools
     if len(sys.argv) <= 2:
       tools_to_activate = list(tools)
@@ -1413,37 +1421,37 @@ def main():
         if tool == None:
           tool = find_sdk(sys.argv[i])
         if tool == None:
-          print "Error: No tool or SDK found by name '" + sys.argv[i] + "'."
+          print("Error: No tool or SDK found by name '" + sys.argv[i] + "'.")
           return 1
         tools_to_activate += [tool]
     tools_to_activate = set_active_tools(tools_to_activate, permanently_activate=permanently_activate)
     if WINDOWS and not permanently_activate:
-      print 'To permanently register this environment globally to all users in Windows Registry, rerun the command with the option --global.'
+      print('To permanently register this environment globally to all users in Windows Registry, rerun the command with the option --global.')
     return 0
   elif cmd == 'install':
     if len(sys.argv) <= 2:
-      print "Missing parameter. Type 'emsdk install <tool name>' to install a tool or an SDK. Type 'emsdk list' to obtain a list of available tools. Type 'emsdk install latest' to automatically install the newest version of the SDK."
+      print("Missing parameter. Type 'emsdk install <tool name>' to install a tool or an SDK. Type 'emsdk list' to obtain a list of available tools. Type 'emsdk install latest' to automatically install the newest version of the SDK.")
       return 1
     tool = find_tool(sys.argv[2])
     if tool == None:
       tool = find_sdk(sys.argv[2])
     if tool == None:
-      print "Error: No tool or SDK found by name '" + sys.argv[2] + "'."
+      print("Error: No tool or SDK found by name '" + sys.argv[2] + "'.")
       return 1
     success = tool.install()
     if not success:
       return 1
   elif cmd == 'uninstall':
     if len(sys.argv) <= 2:
-      print "Syntax error. Call 'emsdk uninstall <tool name>'. Call 'emsdk list' to obtain a list of available tools."
+      print("Syntax error. Call 'emsdk uninstall <tool name>'. Call 'emsdk list' to obtain a list of available tools.")
       return 1
     tool = find_tool(sys.argv[2])
     if tool == None:
-      print "Error: Tool by name '" + sys.argv[2] + "' was not found."
+      print("Error: Tool by name '" + sys.argv[2] + "' was not found.")
       return 1
     tool.uninstall()
   else:
-    print "Unknown command '" + cmd + "' given! Type 'emsdk help' to get a list of commands."
+    print("Unknown command '" + cmd + "' given! Type 'emsdk help' to get a list of commands.")
     return 1
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `python` binary invoked by `emsdk` might be Python 3. But the script isn't ready to run under Python 3. With these changes, I at least managed to get a setup installed and activated using Python 3, so it looks good even though I can't guarantee that I got the unicode versus bytes distinction correct in all places. Python 2.7 should be fine as well. And I doubt we should care too much for Python versions older than that.

Compare kripken/emscripten#792 about Python 3 support in emscripten itself.