### PR TITLE
Use $0 to get execution path

### DIFF
--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -17,7 +17,7 @@
 
 SRC="$BASH_SOURCE"
 if [ "$SRC" = "" ]; then
-  SRC="$_"
+  SRC="$0"
 fi
 pushd `dirname "$SRC"` > /dev/null
 unset SRC


### PR DESCRIPTION
$_ is "The last argument of the previous command." (cf. man zshparam) on zsh, so SRC will be "]".