### PR TITLE
New command-line option --shallow

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -400,7 +400,6 @@ def git_clone(url, dstpath):
   return run([GIT(), 'clone', url, dstpath]) == 0
 
 def git_checkout_and_pull(repo_path, branch):
-  run([GIT(), 'fetch', 'origin'], repo_path)
   try:
     print("Fetching latest changes to the branch '" + branch + "' for '" + repo_path + "'...")
     run([GIT(), 'fetch', 'origin'], repo_path)

--- a/emsdk
+++ b/emsdk
@@ -43,7 +43,9 @@ if platform.mac_ver()[0] != '':
 
 CPU_CORES = max(multiprocessing.cpu_count()-1, 1) # Don't saturate all cores to not steal the whole system, but be aggressive.
 
-CMAKE_BUILD_TYPE_OVERRIDE = None
+# These variables will be changed by command-line options
+CMAKE_BUILD_TYPE_OVERRIDE = None # --build=...
+USE_SHALLOW_GIT = False # --shallow
 
 emscripten_config_directory = os.path.expanduser("~/")
 
@@ -397,12 +399,18 @@ def git_clone(url, dstpath):
     print("Repository '" + url + "' already cloned to directory '" + dstpath + "', skipping.")
     return True
   mkdir_p(dstpath)
-  return run([GIT(), 'clone', url, dstpath]) == 0
+  if USE_SHALLOW_GIT:
+    return run([GIT(), 'clone', '--depth', '1', url, dstpath]) == 0
+  else:
+    return run([GIT(), 'clone', url, dstpath]) == 0
 
 def git_checkout_and_pull(repo_path, branch):
   try:
     print("Fetching latest changes to the branch '" + branch + "' for '" + repo_path + "'...")
-    run([GIT(), 'fetch', 'origin'], repo_path)
+    if USE_SHALLOW_GIT:
+      run([GIT(), 'fetch', '--depth', '1', 'origin'], repo_path)
+    else:
+      run([GIT(), 'fetch', 'origin'], repo_path)
 #  run([GIT, 'checkout', '-b', branch, '--track', 'origin/'+branch], repo_path)
     run([GIT(), 'checkout', '--quiet', branch], repo_path) # this line assumes that the user has not gone and manually messed with the repo and added new remotes to ambiguate the checkout.
     run([GIT(), 'merge', '--ff-only', 'origin/'+branch], repo_path) # this line assumes that the user has not gone and made local changes to the repo
@@ -1333,12 +1341,14 @@ def main():
    emsdk update                 - Fetches a list of updates from the net (but
                                   does not install them)
 
-   emsdk install [-j<num>] [--build=type] <tool/sdk>
+   emsdk install [-j<num>] [--shallow] [--build=type] <tool/sdk>
                                 - Downloads and installs the given tool or SDK.
                                   An optional -j<num> specifier can be used to
                                   specify the number of cores to use when
-                                  building the tool. (default: use one less
-                                  than the # of detected cores)
+                                  building the tool (default: use one less
+                                  than the # of detected cores). If the
+                                  --shallow option is passed, shallow git
+                                  repositories are used.
 
    emsdk uninstall <tool/sdk>   - Removes the given tool or SDK from disk.''')
 
@@ -1401,6 +1411,10 @@ def main():
       else:
         print("Invalid command line parameter " + sys.argv[i] + ' specified!', file=sys.stderr)
         return 1
+    if sys.argv[i] == '--shallow':
+      global USE_SHALLOW_GIT
+      USE_SHALLOW_GIT = True
+      sys.argv[i] = ''
   sys.argv = [x for x in sys.argv if not len(x) == 0]
 
   # Replace meta-packages with the real package names.


### PR DESCRIPTION
As discussed on kripken/emscripten#2750 (and, earlier, juj/emsdk#14), this adds optional support for shallow cloning, toggled by the command-line option `--shallow`. It passes `--depth 1` to git.

When used, this provides a significant increase in download speed when emsdk clones a large repository like kripken/emscripten-fastcomp, especially when running on a slower connection.
As a comparison, I've cloned kripken/emscripten-fastcomp with and without `--depth 1`:
```
$ time git clone --depth 1 https://github.com/kripken/emscripten-fastcomp/ emscripten-fastcomp-shallow
Cloning into 'emscripten-fastcomp-shallow'...
remote: Counting objects: 16387, done.
remote: Compressing objects: 100% (15195/15195), done.
remote: Total 16387 (delta 1840), reused 7017 (delta 1068), pack-reused 0
Receiving objects: 100% (16387/16387), 20.60 MiB | 8.40 MiB/s, done.
Resolving deltas: 100% (1840/1840), done.

real    0m7.673s
user    0m1.684s
sys     0m0.372s


$ time git clone https://github.com/kripken/emscripten-fastcomp/
Cloning into 'emscripten-fastcomp'...
remote: Counting objects: 949921, done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 949921 (delta 6), reused 0 (delta 0), pack-reused 949906
Receiving objects: 100% (949921/949921), 172.65 MiB | 31.77 MiB/s, done.
Resolving deltas: 100% (779495/779495), done.

real    0m39.561s
user    0m36.238s
sys     0m2.124s

```
As you can see, it reduces the amount of data which git-clone downloads by more than 85%.