### PR TITLE
Make .emscripten config file relocatable when using the --embedded flag

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -724,6 +724,7 @@ def generate_dot_emscripten(active_tools):
   if emscripten_config_directory == emsdk_path():
     temp_dir = sdk_path('tmp')
     mkdir_p(temp_dir)
+    embedded=True
   else:
     temp_dir = tempfile.gettempdir().replace('\\', '/')
 
@@ -731,6 +732,9 @@ def generate_dot_emscripten(active_tools):
   has_node = False
 
   cfg = 'import os\n'
+  
+  if embedded:
+    cfg += 'emsdk_path=os.path.dirname(EM_CONFIG)\n'
 
   for tool in active_tools:
     tool_cfg = tool.activated_config()
@@ -753,6 +757,9 @@ TEMP_DIR = ''' + "'" + temp_dir + "'" + '''
 COMPILER_ENGINE = NODE_JS
 JS_ENGINES = [NODE_JS]
 '''
+
+  if embedded:
+    cfg = cfg.replace(emscripten_config_directory, '\' + emsdk_path + \'')
 
   with open(dot_emscripten_path(), "w") as text_file: text_file.write(cfg)
   


### PR DESCRIPTION
I'd like to copy the emsdk directory around freely. The --embedded option almost does the job but it still leaves absolute paths in the .emscripten config file. This change will make all absolute paths derived from the location of the .emscripten file itself. I tested this briefly for my setup and it seems to work. Could you please merge this?