### PR TITLE
Fix tag compilation for Linux 64bit and Unix 32bit

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -842,8 +842,20 @@
     "version": "tag-%tag%",
     "bitness": 64,
     "uses": ["clang-tag-e%tag%-64bit", "node-4.1.1-64bit", "emscripten-tag-%tag%-64bit"],
+    "os": "linux"
+  },
+  {
+    "version": "tag-%tag%",
+    "bitness": 32,
+    "uses": ["clang-tag-e%tag%-32bit", "node-4.1.1-32bit", "emscripten-tag-%tag%-32bit"],
     "os": "unix"
-  },  
+  },
+  {
+    "version": "tag-%tag%",
+    "bitness": 64,
+    "uses": ["clang-tag-e%tag%-64bit", "node-4.1.1-64bit", "emscripten-tag-%tag%-64bit"],
+    "os": "unix"
+  },
   {
     "version": "1.5.6",
     "bitness": 32,


### PR DESCRIPTION
Before this patch it was impossible to compile from tag 64bit version of SDK on Linux host and 32bit version of SDK under Unix operation system.

Tested on Ubuntu with command:
```
./emsdk install sdk-tag-1.35.0-64bit
```