### PR TITLE
Explicitly specify python2

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import sys, optparse, subprocess, os, os.path, errno, zipfile, string, json, platform, shutil, tarfile, tempfile, multiprocessing, re, stat, copy


### PR DESCRIPTION
Allows for compatability with environments where Python 3
is default (like Arch based Linux distros).