### PR TITLE
Fix VS2015 build

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -570,7 +570,7 @@ def find_msbuild(sln_file):
   if '# Visual Studio Express 2015' in contents or '# Visual Studio 2015' in contents or '# Visual Studio 14' in contents:
     search_paths = search_paths_vs2015
     make_env['VCTargetsPath'] = os.path.join(os.environ['ProgramFiles(x86)'], 'MSBuild/Microsoft.Cpp/v4.0/V140')
-  if '# Visual Studio Express 2013' in contents or '# Visual Studio 2013' in contents or '# Visual Studio 12' in contents:
+  elif '# Visual Studio Express 2013' in contents or '# Visual Studio 2013' in contents or '# Visual Studio 12' in contents:
     search_paths = search_paths_vs2013 + search_paths_old
     make_env['VCTargetsPath'] = os.path.join(os.environ['ProgramFiles(x86)'], 'MSBuild/Microsoft.Cpp/v4.0/V120')
   else:


### PR DESCRIPTION
Without this change, building with VS2015 would fail because a wrong MSBuild.exe would be found (through `search_paths_old`).
