### PR TITLE
Call emsdk_env.bat without changing curr dir

### DIFF
--- a/emsdk_env.bat
+++ b/emsdk_env.bat
@@ -1,1 +1,1 @@
-@call emsdk construct_env %*
+@call "%~dp0emsdk" construct_env %*


### PR DESCRIPTION
Previously user needs to switch current directory to the location of `emsdk_env.bat`, call it, then switch back to previous directory to continue his works.