### PR TITLE
Catch KeyboardInterupt in download_file

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -487,6 +487,10 @@ def download_file(url, dstpath, download_even_if_exists=False, filename_prefix =
     print("Error downloading URL '" + url + "': " + str(e))
     rmfile(file_name)
     return None
+  except KeyboardInterrupt as e:
+    print("Received Interrupt, exiting")
+    rmfile(file_name)
+    exit(0)
   return file_name
 
 def download_text_file(url, dstpath, download_even_if_exists=False, filename_prefix=''):

--- a/emsdk
+++ b/emsdk
@@ -488,9 +488,9 @@ def download_file(url, dstpath, download_even_if_exists=False, filename_prefix =
     rmfile(file_name)
     return None
   except KeyboardInterrupt as e:
-    print("Received Interrupt, exiting")
+    print("Aborted by User, exiting")
     rmfile(file_name)
-    exit(0)
+    exit(1)
   return file_name
 
 def download_text_file(url, dstpath, download_even_if_exists=False, filename_prefix=''):


### PR DESCRIPTION
When interrupting a download with something like control c the program will quit but won't clean it self up and will leave an invalid file. There is a handler for Exception, but this wont catch interrupts. If you try to rerun the program it won't try to re-download it the next time.