### PR TITLE
Explicitly use bourne shell

### DIFF
--- a/emsdk_env.sh
+++ b/emsdk_env.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # This script is sourced by the user and uses
 # their shell. Try not to use bashisms.
 


### PR DESCRIPTION
So that users with non-sh-compatible shells including Fish can source it. sh-compatible shells including bash will see no change.

Fixes #111.