### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,17 @@
-sudo: false
-dist: trusty
-language: cpp
+sudo: required
 
-stages:
-  - name: test
-  - name: build
+language: python
 
-jobs:
-  include:
-    - &test-ubuntu
-      stage: test
-      compiler: clang
-      python: 2.7
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['cmake', 'g++-5']
-      script:
-        # install latest tag
-        - ./emsdk install latest
-        - ./emsdk activate latest
-        - source ./emsdk_env.sh --build=Release
-        # verify building works
-        - echo "int main() {}" > hello_world.cpp
-        - emcc hello_world.cpp
+services:
+  - docker
+
+before_install:
+  - docker pull ubuntu:16.04
+
+script:
+  - set -o errexit
+  - echo "running..."
+  - docker build --build-arg TEST_TARGET="$TEST_TARGET" .
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ jobs:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['cmake', 'g++-5']
       script:
+        # install latest tag
         - ./emsdk install latest
         - ./emsdk activate latest
         - source ./emsdk_env.sh --build=Release
+        # verify building works
         - echo "int main() {}" > hello_world.cpp
         - emcc hello_world.cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: false
+dist: trusty
+language: cpp
+
+stages:
+  - name: test
+  - name: build
+
+jobs:
+  include:
+    - &test-ubuntu
+      stage: test
+      compiler: clang
+      python: 2.7
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['cmake', 'g++-5']
+      script:
+        - ./emsdk install latest
+        - ./emsdk activate latest
+        - source ./emsdk_env.sh --build=Release
+        - echo "int main() {}" > hello_world.cpp
+        - emcc hello_world.cpp
+
+notifications:
+  email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ COPY . /root/emscripten/
 RUN cd /root/ \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
- && ./emsdk install latest
- && ./emsdk activate latest
- && source ./emsdk_env.sh --build=Release
- && echo "int main() {}" > hello_world.cpp
+ && ./emsdk install latest \
+ && ./emsdk activate latest \
+ && source ./emsdk_env.sh --build=Release \
+ && echo "int main() {}" > hello_world.cpp \
  && emcc hello_world.cpp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# For travis
+FROM buildpack-deps:xenial
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
+RUN mkdir -p /root/emscripten/
+COPY . /root/emscripten/
+
+RUN cd /root/ \
+ && apt-get update \
+ && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
+ && ./emsdk install latest
+ && ./emsdk activate latest
+ && source ./emsdk_env.sh --build=Release
+ && echo "int main() {}" > hello_world.cpp
+ && emcc hello_world.cpp
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@
 FROM buildpack-deps:xenial
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
-RUN mkdir -p /root/emscripten/
-COPY . /root/emscripten/
+RUN mkdir -p /root/emsdk/
+COPY . /root/emsdk/
 
 RUN cd /root/ \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
- && ./emsdk install latest \
- && ./emsdk activate latest \
- && source ./emsdk_env.sh --build=Release \
+ && /root/emsdk/emsdk install latest \
+ && /root/emsdk/emsdk activate latest \
+ && source /root/emsdk/emsdk_env.sh --build=Release \
  && echo "int main() {}" > hello_world.cpp \
  && emcc hello_world.cpp
 


### PR DESCRIPTION
This adds basic travis testing support - it gets the latest tag and verifies we can build a hello world program with it.

I verified this works in kripken/emsdk. To enable travis in this repo, @juj please go to https://travis-ci.org/ and enable juj/emsdk there.