### PR TITLE
binaryen.js is no longer bundled in binaryen

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -937,7 +937,6 @@ def build_binaryen_tool(tool):
   shutil.copytree(os.path.join(src_root, 'scripts'), os.path.join(build_root, 'scripts'))
   remove_tree(os.path.join(build_root, 'src', 'js'))
   shutil.copytree(os.path.join(src_root, 'src', 'js'), os.path.join(build_root, 'src', 'js'))
-  shutil.copyfile(os.path.join(src_root, 'bin', 'binaryen.js'), os.path.join(build_root, 'bin', 'binaryen.js'))
   shutil.copyfile(os.path.join(src_root, 'bin', 'wasm.js'), os.path.join(build_root, 'bin', 'wasm.js'))
 
   return success


### PR DESCRIPTION
And emscripten doesn't need it anyhow (it's for handwritten js users).

This binaryen change broke tagged version building,

http://ec2-54-213-252-128.us-west-2.compute.amazonaws.com:8112/#/builders/5/builds/193

Hopefully this will fix it, although I'm unsure how the bots receive updates to the emsdk script - @juj, do you know?