### PR TITLE
LLVM_ROOT

### DIFF
--- a/emsdk
+++ b/emsdk
@@ -1270,14 +1270,13 @@ class Tool:
   # Returns true if the system environment variables requires by this tool are currently active.
   def is_env_active(self):
     if hasattr(self, 'activated_env'):
-      (key, value) = parse_key_value(self.activated_environment())
-      if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value):
-        if VERBOSE: print(str(self) + ' is not active, because environment variable key="' + key + '" has value "' + str(os.getenv(key)) + '" but should have value "' + value + '"')
-        return False
-#      if WINDOWS:
-#        env_var = win_get_active_environment_variable(key)
-#        if env_var != value:
-#          return False
+      envs = self.activated_environment().split(';')
+      for env in envs:
+        (key, value) = parse_key_value(env)
+        if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value):
+          if VERBOSE: print(str(self) + ' is not active, because environment variable key="' + key + '" has value "' + str(os.getenv(key)) + '" but should have value "' + value + '"')
+          return False
+
     if hasattr(self, 'activated_path'):
       path = self.expand_vars(self.activated_path).replace('\\', '/')
       path = path.split(ENVPATH_SEPARATOR)
@@ -1290,11 +1289,14 @@ class Tool:
 
   def win_activate_env_vars(self, permanently_activate):
     if WINDOWS and hasattr(self, 'activated_env'):
-      (key, value) = parse_key_value(self.activated_environment())
-      if permanently_activate:
-        win_delete_environment_variable(key, False) # If there is an env var for the LOCAL USER with same name, it will hide the system var, so must remove that first.
+      envs = self.activated_environment().split(';')
+      for env in envs:
+        (key, value) = parse_key_value(env)
 
-      win_set_environment_variable(key, value, permanently_activate)
+        if permanently_activate:
+          win_delete_environment_variable(key, False) # If there is an env var for the LOCAL USER with same name, it will hide the system var, so must remove that first.
+
+        win_set_environment_variable(key, value, permanently_activate)
 
   # If this tool can be installed on this system, this function returns True.
   # Otherwise, this function returns a string that describes the reason why this tool is not available.
@@ -1955,10 +1957,12 @@ def construct_env(tools_to_activate, permanent):
 
   for tool in tools_to_activate:
     if hasattr(tool, 'activated_env'):
-      (key, value) = parse_key_value(tool.activated_env)
-      value = to_native_path(tool.expand_vars(value))
-      if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value): # Don't set env. vars which are already set to the correct value.
-        env_vars_to_add += [(key, value)]
+      envs = tool.activated_environment().split(';')
+      for env in envs:
+        (key, value) = parse_key_value(env)
+        value = to_native_path(tool.expand_vars(value))
+        if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value): # Don't set env. vars which are already set to the correct value.
+          env_vars_to_add += [(key, value)]
 
   if len(env_vars_to_add) > 0:
     print('Setting environment variables:')

--- a/emsdk
+++ b/emsdk
@@ -1171,9 +1171,9 @@ class Tool:
 
   def activated_environment(self):
     if hasattr(self, 'activated_env'):
-      return self.expand_vars(self.activated_env)
+      return self.expand_vars(self.activated_env).split(';')
     else:
-      return ''
+      return []
 
   def compatible_with_this_os(self):
     if hasattr(self, 'os'):
@@ -1269,13 +1269,12 @@ class Tool:
 
   # Returns true if the system environment variables requires by this tool are currently active.
   def is_env_active(self):
-    if hasattr(self, 'activated_env'):
-      envs = self.activated_environment().split(';')
-      for env in envs:
-        (key, value) = parse_key_value(env)
-        if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value):
-          if VERBOSE: print(str(self) + ' is not active, because environment variable key="' + key + '" has value "' + str(os.getenv(key)) + '" but should have value "' + value + '"')
-          return False
+    envs = self.activated_environment()
+    for env in envs:
+      (key, value) = parse_key_value(env)
+      if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value):
+        if VERBOSE: print(str(self) + ' is not active, because environment variable key="' + key + '" has value "' + str(os.getenv(key)) + '" but should have value "' + value + '"')
+        return False
 
     if hasattr(self, 'activated_path'):
       path = self.expand_vars(self.activated_path).replace('\\', '/')
@@ -1288,8 +1287,8 @@ class Tool:
     return True
 
   def win_activate_env_vars(self, permanently_activate):
-    if WINDOWS and hasattr(self, 'activated_env'):
-      envs = self.activated_environment().split(';')
+    if WINDOWS:
+      envs = self.activated_environment()
       for env in envs:
         (key, value) = parse_key_value(env)
 
@@ -1956,13 +1955,12 @@ def construct_env(tools_to_activate, permanent):
     mkdir_p(em_cache_dir)
 
   for tool in tools_to_activate:
-    if hasattr(tool, 'activated_env'):
-      envs = tool.activated_environment().split(';')
-      for env in envs:
-        (key, value) = parse_key_value(env)
-        value = to_native_path(tool.expand_vars(value))
-        if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value): # Don't set env. vars which are already set to the correct value.
-          env_vars_to_add += [(key, value)]
+    envs = tool.activated_environment()
+    for env in envs:
+      (key, value) = parse_key_value(env)
+      value = to_native_path(tool.expand_vars(value))
+      if not key in os.environ or to_unix_path(os.environ[key]) != to_unix_path(value): # Don't set env. vars which are already set to the correct value.
+        env_vars_to_add += [(key, value)]
 
   if len(env_vars_to_add) > 0:
     print('Setting environment variables:')

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -444,6 +444,7 @@
     "windows_url": "python_2.7.5.1_32bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "PYTHON='%installation_dir%/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python%.exe%",
     "is_old": true
   },
   {
@@ -453,6 +454,7 @@
     "windows_url": "python_2.7.5_64bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "PYTHON='%installation_dir%/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python%.exe%",
     "is_old": true
   },
   {
@@ -462,6 +464,7 @@
     "windows_url": "python_2.7.5.3_32bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "PYTHON='%installation_dir%/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python%.exe%",
     "is_old": true
   },
   {
@@ -471,6 +474,7 @@
     "windows_url": "python_2.7.5.3_64bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "PYTHON='%installation_dir%/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python%.exe%",
     "is_old": true
   },
   {
@@ -479,7 +483,8 @@
     "bitness": 32,
     "windows_url": "WinPython-32bit-2.7.13.1Zero.zip",
     "activated_path": "%installation_dir%/python-2.7.13",
-    "activated_cfg": "PYTHON='%installation_dir%/python-2.7.13/python%.exe%'"
+    "activated_cfg": "PYTHON='%installation_dir%/python-2.7.13/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-2.7.13/python%.exe%"
   },
   {
     "id": "python",
@@ -487,7 +492,8 @@
     "bitness": 64,
     "windows_url": "WinPython-64bit-2.7.13.1Zero.zip",
     "activated_path": "%installation_dir%/python-2.7.13.amd64",
-    "activated_cfg": "PYTHON='%installation_dir%/python-2.7.13.amd64/python%.exe%'"
+    "activated_cfg": "PYTHON='%installation_dir%/python-2.7.13.amd64/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-2.7.13.amd64/python%.exe%"
   },
   {
     "id": "python",
@@ -495,7 +501,8 @@
     "bitness": 32,
     "windows_url": "WinPython-32bit-3.5.4.1Zero.zip",
     "activated_path": "%installation_dir%/python-3.5.4",
-    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4/python%.exe%'"
+    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-3.5.4/python%.exe%"
   },
   {
     "id": "python",
@@ -503,7 +510,8 @@
     "bitness": 64,
     "windows_url": "WinPython-64bit-3.5.4.1Zero.zip",
     "activated_path": "%installation_dir%/python-3.5.4.amd64",
-    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4.amd64/python%.exe%'"
+    "activated_cfg": "PYTHON='%installation_dir%/python-3.5.4.amd64/python%.exe%'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python-3.5.4.amd64/python%.exe%"
   },
   {
     "id": "java",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -275,7 +275,7 @@
     "osx_url": "emscripten-clang_e1.29.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%",
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%",
     "is_old": true
   },
   {
@@ -286,7 +286,7 @@
     "osx_url": "emscripten-clang_e1.30.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%"
   },
   {
     "id": "clang",
@@ -296,7 +296,7 @@
     "osx_url": "emscripten-clang_e1.34.1.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%"
   },
   {
     "id": "clang",
@@ -306,7 +306,7 @@
     "osx_url": "emscripten-clang_e1.35.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
-    "activated_env": "LLVM_ROOT=%installation_dir%"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%"
   },
   {
     "id": "clang",
@@ -317,7 +317,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e1.37.1.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "LLVM_ROOT=%installation_dir%;BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen"
   },
   {
     "id": "clang",
@@ -328,7 +328,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e%precompiled_tag32%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "LLVM_ROOT=%installation_dir%;BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen"
   },
   {
     "id": "clang",
@@ -339,7 +339,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e%precompiled_tag64%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "LLVM_ROOT=%installation_dir%;BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%/optimizer%.exe%;BINARYEN_ROOT=%installation_dir%/binaryen"
   },
   {
     "id": "node",
@@ -818,7 +818,7 @@
     "zipfile_prefix": "emscripten-e",
     "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%'",
     "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%",
+    "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
     "custom_install_script": "build_optimizer",
     "custom_is_installed_script": "is_optimizer_installed",
@@ -833,7 +833,7 @@
     "unix_url": "https://github.com/kripken/emscripten/archive/%tag%.tar.gz",
     "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%'",
     "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%",
+    "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
     "custom_install_script": "build_optimizer",
     "custom_is_installed_script": "is_optimizer_installed",
@@ -898,7 +898,7 @@
     "git_branch": "incoming",
     "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%'",
     "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%",
+    "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
     "custom_install_script": "build_optimizer",
     "custom_is_installed_script": "is_optimizer_installed",
@@ -913,7 +913,7 @@
     "git_branch": "master",
     "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%'",
     "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%",
+    "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_32bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
     "custom_install_script": "build_optimizer",
     "custom_is_installed_script": "is_optimizer_installed",
@@ -928,7 +928,7 @@
     "git_branch": "incoming",
     "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%'",
     "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%",
+    "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
     "custom_install_script": "build_optimizer",
     "custom_is_installed_script": "is_optimizer_installed",
@@ -943,7 +943,7 @@
     "git_branch": "master",
     "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%'",
     "activated_path": "%installation_dir%",
-    "activated_env": "EMSCRIPTEN=%installation_dir%",
+    "activated_env": "EMSCRIPTEN=%installation_dir%;EMSCRIPTEN_NATIVE_OPTIMIZER=%installation_dir%%generator_prefix%_64bit_optimizer/%cmake_build_type_on_win%optimizer%.exe%",
     "cmake_build_type": "Release",
     "custom_install_script": "build_optimizer",
     "custom_is_installed_script": "is_optimizer_installed",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -349,6 +349,7 @@
     "windows_install_path": "node/0.10.17_32bit/node.exe",
     "activated_path": "%installation_dir%",
     "activated_cfg": "NODE_JS='%installation_dir%/node.exe'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/node.exe",
     "is_old": true
   },
   {
@@ -359,6 +360,7 @@
     "windows_install_path": "node/0.10.17_64bit/node.exe",
     "activated_path": "%installation_dir%",
     "activated_cfg": "NODE_JS='%installation_dir%/node.exe'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/node.exe",
     "is_old": true
   },
   {
@@ -368,6 +370,7 @@
     "osx_url": "node-v0.10.18-darwin-x64.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node",
     "is_old": true
   },
   {
@@ -378,6 +381,7 @@
     "windows_install_path": "node/0.12.2_32bit/node.exe",
     "activated_path": "%installation_dir%",
     "activated_cfg": "NODE_JS='%installation_dir%/node.exe'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/node.exe",
     "is_old": true
   },
   {
@@ -388,6 +392,7 @@
     "windows_install_path": "node/0.12.2_64bit/node.exe",
     "activated_path": "%installation_dir%",
     "activated_cfg": "NODE_JS='%installation_dir%/node.exe'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/node.exe",
     "is_old": true
   },
   {
@@ -397,6 +402,7 @@
     "osx_url": "node-v0.12.2-darwin-x64.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node",
     "is_old": true
   },
   {
@@ -406,7 +412,8 @@
     "windows_url": "node_4.1.1_32bit.zip",
     "linux_url": "node-v4.1.1-linux-x86.tar.gz",
     "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'"
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
@@ -416,7 +423,8 @@
     "windows_url": "node_4.1.1_64bit.zip",
     "linux_url": "node-v4.1.1-linux-x64.tar.gz",
     "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'"
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
@@ -425,7 +433,8 @@
     "windows_url": "node-v8.9.1-win-x86.zip",
     "linux_url": "node-v8.9.1-linux-x86.tar.xz",
     "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'"
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "node",
@@ -435,7 +444,8 @@
     "windows_url": "node-v8.9.1-win-x64.zip",
     "linux_url": "node-v8.9.1-linux-x64.tar.xz",
     "activated_path": "%installation_dir%/bin",
-    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'"
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
   {
     "id": "python",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -7,6 +7,7 @@
     "windows_url": "clang_3.2_32bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -16,6 +17,7 @@
     "windows_url": "clang_3.2_64bit.zip",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/bin'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/bin",
     "is_old": true
   },
   {
@@ -25,6 +27,7 @@
     "windows_url": "clang_3.3_32bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -34,6 +37,7 @@
     "windows_url": "clang_3.3_64bit.zip",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -43,6 +47,7 @@
     "osx_url": "clang%2Bllvm-3.2-x86_64-apple-darwin11.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/bin'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/bin",
     "is_old": true
   },
   {
@@ -52,6 +57,7 @@
     "osx_url": "clang%2Bllvm-3.3-x86_64-apple-darwin12.tar.gz",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/bin'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/bin",
     "is_old": true
   },
   {
@@ -66,6 +72,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -80,6 +87,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -91,7 +99,8 @@
     "osx_url": "llvm/nightly/osx_64bit/emscripten-llvm-e%nightly-llvm-64bit%.tar.gz",
     "linux_url": "llvm/nightly/linux_64bit/emscripten-llvm-e%nightly-llvm-64bit%.tar.gz",
     "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%'"
+    "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%"
   },
   {
     "id": "clang",
@@ -104,6 +113,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -117,6 +127,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -130,6 +141,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -143,6 +155,7 @@
     "custom_install_script": "build_fastcomp",
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -158,6 +171,7 @@
     "only_supports_wasm": true,
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -173,6 +187,7 @@
     "only_supports_wasm": true,
     "activated_path": "%installation_dir%/%fastcomp_build_bin_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%/%fastcomp_build_bin_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%/%fastcomp_build_bin_dir%",
     "cmake_build_type": "Release"
   },
   {
@@ -183,6 +198,7 @@
     "osx_url": "emscripten-clang_e1.13.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -193,6 +209,7 @@
     "osx_url": "emscripten-clang_e1.13.1.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -203,6 +220,7 @@
     "osx_url": "emscripten-clang_e1.16.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -213,6 +231,7 @@
     "osx_url": "emscripten-clang_e1.21.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -223,6 +242,7 @@
     "osx_url": "emscripten-clang_e1.22.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -233,6 +253,7 @@
     "osx_url": "emscripten-clang_e1.25.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -243,6 +264,7 @@
     "osx_url": "emscripten-clang_e1.27.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -253,6 +275,7 @@
     "osx_url": "emscripten-clang_e1.29.0.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%",
     "is_old": true
   },
   {
@@ -262,7 +285,8 @@
     "windows_url": "emscripten-clang_e1.30.0.zip",
     "osx_url": "emscripten-clang_e1.30.0.tar.gz",
     "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'"
+    "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%"
   },
   {
     "id": "clang",
@@ -271,7 +295,8 @@
     "windows_url": "emscripten-clang_e1.34.1.zip",
     "osx_url": "emscripten-clang_e1.34.1.tar.gz",
     "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'"
+    "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%"
   },
   {
     "id": "clang",
@@ -280,7 +305,8 @@
     "windows_url": "emscripten-clang_e1.35.0.zip",
     "osx_url": "emscripten-clang_e1.35.0.tar.gz",
     "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'"
+    "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%'",
+    "activated_env": "LLVM_ROOT=%installation_dir%"
   },
   {
     "id": "clang",
@@ -291,7 +317,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e1.37.1.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;BINARYEN_ROOT=%installation_dir%/binaryen"
   },
   {
     "id": "clang",
@@ -302,7 +328,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e%precompiled_tag32%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;BINARYEN_ROOT=%installation_dir%/binaryen"
   },
   {
     "id": "clang",
@@ -313,7 +339,7 @@
     "linux_url": "llvm/tag/linux_64bit/emscripten-llvm-e%precompiled_tag64%.tar.gz",
     "activated_path": "%installation_dir%",
     "activated_cfg": "LLVM_ROOT='%installation_dir%';EMSCRIPTEN_NATIVE_OPTIMIZER='%installation_dir%/optimizer%.exe%';BINARYEN_ROOT='%installation_dir%/binaryen'",
-    "activated_env": "BINARYEN_ROOT=%installation_dir%/binaryen"
+    "activated_env": "LLVM_ROOT=%installation_dir%;BINARYEN_ROOT=%installation_dir%/binaryen"
   },
   {
     "id": "node",


### PR DESCRIPTION
This PR adds the `LLVM_ROOT` environment variable to also be registered (in addition to setting it in cfg) so that users can easily locate where clang executable resides.