### PR TITLE
Enable "emsdk [install|activate] latest-upstream"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && rm ~/.emscripten \
  && /root/emsdk/emsdk update-tags \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,7 @@ RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
- && /root/emsdk/emsdk install latest \
- && /root/emsdk/emsdk activate latest \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
+ && /root/emsdk/emsdk update-tags \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,7 @@ RUN cd /root/ \
  && emcc hello_world.cpp \
  && /root/emsdk/emsdk update-tags \
  && /root/emsdk/emsdk install latest-upstream \
- && echo "activate!" \
  && /root/emsdk/emsdk activate latest-upstream \
- && echo "activated" \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && find -name "emcc.py" \
- && emcc hello_world.cpp \
+ && emcc hello_world.cpp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,5 @@ RUN cd /root/ \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -o a.bc \
- && export EMCC_DEBUG=1 \
- && emcc a.bc
+ && emcc hello_world.cpp -s WASM_OBJECT_FILES=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM buildpack-deps:xenial
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
+ENV EMCC_DEBUG=1
 RUN mkdir -p /root/emsdk/
 COPY . /root/emsdk/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
+ && echo "update tagz" \
  && /root/emsdk/emsdk update-tags \
+ && echo "updated maybe" \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,15 @@ RUN mkdir -p /root/emsdk/
 COPY . /root/emsdk/
 
 RUN cd /root/ \
+ && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
  && /root/emsdk/emsdk install latest \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && echo "int main() {}" > hello_world.cpp \
- && emcc hello_world.cpp
+ && emcc hello_world.cpp \
+ && /root/emsdk/emsdk install latest-upstream \
+ && /root/emsdk/emsdk activate latest-upstream \
+ && source /root/emsdk/emsdk_env.sh --build=Release \
+ && emcc hello_world.cpp \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
+ && rm ~/.emscripten \
  && /root/emsdk/emsdk update-tags \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM buildpack-deps:xenial
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
-ENV EMCC_DEBUG=1
 RUN mkdir -p /root/emsdk/
 COPY . /root/emsdk/
 
@@ -10,14 +9,11 @@ RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
- && /root/emsdk/emsdk install latest \
- && /root/emsdk/emsdk activate latest \
- && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
- && rm ~/.emscripten \
  && /root/emsdk/emsdk update-tags \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp
+ && emcc hello_world.cpp -o a.bc \
+ && export EMCC_DEBUG=1 \
+ && emcc a.bc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
+ && /root/emsdk/emsdk install latest \
+ && /root/emsdk/emsdk activate latest \
+ && source /root/emsdk/emsdk_env.sh --build=Release \
+ && emcc hello_world.cpp \
+ && rm ~/.emscripten \
  && /root/emsdk/emsdk update-tags \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,16 @@ RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
- && echo "update tagz" \
- && /root/emsdk/emsdk update-tags \
- && echo "updated maybe" \
- && /root/emsdk/emsdk install latest-upstream \
- && /root/emsdk/emsdk activate latest-upstream \
+ && /root/emsdk/emsdk install latest \
+ && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
+ && emcc hello_world.cpp \
+ && /root/emsdk/emsdk update-tags \
+ && /root/emsdk/emsdk install latest-upstream \
+ && echo "activate!" \
+ && /root/emsdk/emsdk activate latest-upstream \
+ && echo "activated" \
+ && source /root/emsdk/emsdk_env.sh --build=Release \
+ && find -name "emcc.py" \
  && emcc hello_world.cpp \
 

--- a/emsdk
+++ b/emsdk
@@ -1700,6 +1700,7 @@ def load_llvm_precompiled_tags_64bit():
   return load_file_index_list('llvm-tags-64bit.txt')
 
 def download_waterfall_lkgr():
+  print('download lkgr!!!!! waka')
   lkgr_url = 'https://storage.googleapis.com/wasm-llvm/builds/linux/lkgr.json'
   download_file(lkgr_url, 'upstream', download_even_if_exists=True)
 

--- a/emsdk
+++ b/emsdk
@@ -1524,6 +1524,9 @@ def find_latest_nightly_sdk():
   else:
     return find_latest_nightly_32bit_sdk()
 
+def find_latest_upstream():
+  return 'clang-upstream-%s-64bit' % load_waterfall_lkgr()[0]
+
 # Finds the best-matching python tool for use.
 def find_used_python():
   for t in reversed(tools): # Find newest tool first - those are always at the end of the list.
@@ -2210,6 +2213,8 @@ def main():
         sys.argv[i] = str(find_latest_nightly_32bit_sdk())
       elif sys.argv[i] == 'sdk-nightly-latest-64bit':
         sys.argv[i] = str(find_latest_nightly_64bit_sdk())
+      elif sys.argv[i] == 'latest-upstream' or sys.argv[i] == 'latest-clang-upstream':
+        sys.argv[i] = str(find_latest_upstream())
 
   if cmd == 'list':
     print('')

--- a/emsdk
+++ b/emsdk
@@ -1142,6 +1142,9 @@ class Tool:
   def __str__(self):
     return self.name
 
+  def __repr__(self):
+    return self.name
+
   def expand_vars(self, str):
     if WINDOWS and '%MSBuildPlatformsDir%' in str:
       str = str.replace('%MSBuildPlatformsDir%', find_msbuild_dir())

--- a/emsdk
+++ b/emsdk
@@ -1705,13 +1705,15 @@ def download_waterfall_lkgr():
 
 def load_waterfall_lkgr():
   try:
-    print('a');
-    data = json.loads(open(os.path.join('upstream', 'lkgr.json'), 'r').read())
+    print('a0');
+    text = open(os.path.join('upstream', 'lkgr.json'), 'r').read()
+    print('a1' + text);
+    data = json.loads(text)
     print('b: ' + str(data));
     lkgr = data['build']
     print('c: ' + str(lkgr));
     return [lkgr]
-  except Exception, as e:
+  except Exception as e:
     print('Error parsing lkgr.json!')
     print(str(e))
     return

--- a/emsdk
+++ b/emsdk
@@ -2006,7 +2006,7 @@ def construct_env(tools_to_activate, permanent):
   # A core variable EMSDK points to the root of Emscripten SDK directory.
   env_vars_to_add += [('EMSDK', to_unix_path(emsdk_path()))]
 
-  em_config_path = os.path.normpath(os.path.join(emscripten_config_directory, '.emscripten'))
+  em_config_path = os.path.normpath(dot_emscripten_path())
   if not 'EM_CONFIG' in os.environ or to_unix_path(os.environ['EM_CONFIG']) != to_unix_path(em_config_path):
     env_vars_to_add += [('EM_CONFIG', em_config_path)]
   if emscripten_config_directory == emsdk_path():

--- a/emsdk
+++ b/emsdk
@@ -1526,8 +1526,7 @@ def find_latest_nightly_sdk():
 
 def find_latest_upstream():
   waterfall_lkgr = load_waterfall_lkgr()
-  print(str(waterfall_lkgr))
-  if len(waterfall_lkgr) == 0:
+  if not waterfall_lkgr:
     print('Failed to find an upstream lkgr')
     sys.exit(1)
   return 'clang-upstream-%s-64bit' % waterfall_lkgr[0]

--- a/emsdk
+++ b/emsdk
@@ -1705,11 +1705,16 @@ def download_waterfall_lkgr():
 
 def load_waterfall_lkgr():
   try:
+    print('a');
     data = json.loads(open(os.path.join('upstream', 'lkgr.json'), 'r').read())
+    print('b: ' + str(data));
     lkgr = data['build']
+    print('c: ' + str(lkgr));
     return [lkgr]
-  except:
-    return []
+  except Exception, as e:
+    print('Error parsing lkgr.json!')
+    print(str(e))
+    return
 
 def is_string(s):
   if (sys.version_info[0] >= 3): return isinstance(s, str)

--- a/emsdk
+++ b/emsdk
@@ -1532,7 +1532,7 @@ def find_latest_upstream():
   if not waterfall_lkgr:
     print('Failed to find an upstream lkgr')
     sys.exit(1)
-  return 'clang-upstream-%s-64bit' % waterfall_lkgr[0]
+  return 'waterfall-upstream-%s-64bit' % waterfall_lkgr[0]
 
 # Finds the best-matching python tool for use.
 def find_used_python():

--- a/emsdk
+++ b/emsdk
@@ -1527,7 +1527,7 @@ def find_latest_nightly_sdk():
   else:
     return find_latest_nightly_32bit_sdk()
 
-def find_latest_upstream():
+def find_latest_upstream_sdk():
   waterfall_lkgr = load_waterfall_lkgr()
   if not waterfall_lkgr:
     print('Failed to find an upstream lkgr')
@@ -2224,7 +2224,7 @@ def main():
       elif sys.argv[i] == 'sdk-nightly-latest-64bit':
         sys.argv[i] = str(find_latest_nightly_64bit_sdk())
       elif sys.argv[i] == 'latest-upstream' or sys.argv[i] == 'latest-clang-upstream':
-        sys.argv[i] = str(find_latest_upstream())
+        sys.argv[i] = str(find_latest_upstream_sdk())
 
   if cmd == 'list':
     print('')

--- a/emsdk
+++ b/emsdk
@@ -1532,7 +1532,7 @@ def find_latest_upstream():
   if not waterfall_lkgr:
     print('Failed to find an upstream lkgr')
     sys.exit(1)
-  return 'waterfall-upstream-%s-64bit' % waterfall_lkgr[0]
+  return 'sdk-upstream-%s-64bit' % waterfall_lkgr[0]
 
 # Finds the best-matching python tool for use.
 def find_used_python():

--- a/emsdk
+++ b/emsdk
@@ -1717,7 +1717,7 @@ def load_waterfall_lkgr():
   except Exception as e:
     print('Error parsing lkgr.json!')
     print(str(e))
-    return
+    return []
 
 def is_string(s):
   if (sys.version_info[0] >= 3): return isinstance(s, str)

--- a/emsdk
+++ b/emsdk
@@ -1525,7 +1525,12 @@ def find_latest_nightly_sdk():
     return find_latest_nightly_32bit_sdk()
 
 def find_latest_upstream():
-  return 'clang-upstream-%s-64bit' % load_waterfall_lkgr()[0]
+  waterfall_lkgr = load_waterfall_lkgr()
+  print(str(waterfall_lkgr))
+  if len(waterfall_lkgr) == 0:
+    print('Failed to find an upstream lkgr')
+    sys.exit(1)
+  return 'clang-upstream-%s-64bit' % waterfall_lkgr[0]
 
 # Finds the best-matching python tool for use.
 def find_used_python():

--- a/emsdk
+++ b/emsdk
@@ -1702,7 +1702,6 @@ def load_llvm_precompiled_tags_64bit():
   return load_file_index_list('llvm-tags-64bit.txt')
 
 def download_waterfall_lkgr():
-  print('download lkgr!!!!! waka')
   lkgr_url = 'https://storage.googleapis.com/wasm-llvm/builds/linux/lkgr.json'
   download_file(lkgr_url, 'upstream', download_even_if_exists=True)
 

--- a/emsdk
+++ b/emsdk
@@ -1706,13 +1706,9 @@ def download_waterfall_lkgr():
 
 def load_waterfall_lkgr():
   try:
-    print('a0');
     text = open(sdk_path(os.path.join('upstream', 'lkgr.json')), 'r').read()
-    print('a1' + text);
     data = json.loads(text)
-    print('b: ' + str(data));
     lkgr = data['build']
-    print('c: ' + str(lkgr));
     return [lkgr]
   except Exception as e:
     print('Error parsing lkgr.json!')

--- a/emsdk
+++ b/emsdk
@@ -1707,7 +1707,7 @@ def download_waterfall_lkgr():
 def load_waterfall_lkgr():
   try:
     print('a0');
-    text = open(os.path.join('upstream', 'lkgr.json'), 'r').read()
+    text = open(sdk_path(os.path.join('upstream', 'lkgr.json')), 'r').read()
     print('a1' + text);
     data = json.loads(text)
     print('b: ' + str(data));

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -191,32 +191,13 @@
     "cmake_build_type": "Release"
   },
   {
-    "id": "clang",
+    "id": "waterfall",
     "version": "upstream-%waterfall-lkgr%",
     "bitness": 64,
     "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
     "install_path": "upstream/%waterfall-lkgr%",
     "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin'"
-  },
-  {
-    "id": "emscripten",
-    "version": "upstream-%waterfall-lkgr%",
-    "bitness": 64,
-    "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
-    "install_path": "upstream/%waterfall-lkgr%",
-    "activated_path": "%installation_dir%",
-    "activated_cfg": "EMSCRIPTEN_ROOT='%installation_dir%/emscripten'"
-  },
-  {
-    "id": "binaryen",
-    "version": "upstream-%waterfall-lkgr%",
-    "bitness": 64,
-    "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
-    "install_path": "upstream/%waterfall-lkgr%",
-    "activated_path": "%installation_dir%",
-    "activated_cfg": "BINARYEN_ROOT='%installation_dir%'",
-    "activated_env": "BINARYEN_ROOT=%installation_dir%"
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT=%installation_dir%"
   },
   {
     "id": "clang",
@@ -1565,7 +1546,7 @@
   {
     "version": "upstream-%waterfall-lkgr%",
     "bitness": 64,
-    "uses": ["clang-upstream-%waterfall-lkgr%-64bit", "emscripten-upstream-%waterfall-lkgr%-64bit", "binaryen-upstream-%waterfall-lkgr%-64bit"],
+    "uses": ["waterfall-upstream-%waterfall-lkgr%-64bit"],
     "os": "linux"
   },
   {

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -196,8 +196,8 @@
     "bitness": 64,
     "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
     "install_path": "upstream/%waterfall-lkgr%",
-    "activated_path": "%installation_dir%",
-    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT=%installation_dir%"
+    "activated_path": "%installation_dir%/emscripten",
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%'"
   },
   {
     "id": "clang",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -1546,7 +1546,7 @@
   {
     "version": "upstream-%waterfall-lkgr%",
     "bitness": 64,
-    "uses": ["waterfall-upstream-%waterfall-lkgr%-64bit"],
+    "uses": ["waterfall-upstream-%waterfall-lkgr%-64bit", "node-8.9.1-64bit"],
     "os": "linux"
   },
   {


### PR DESCRIPTION
This makes it possible to tell the emsdk to get "latest-upstream", which fetches the latest lkgr from there. This will probably be a common use pattern, I expect we may want to recommend users start trying out the wasm backend that way soon. This will also let us simplify this code: https://github.com/kripken/emscripten/blob/incoming/.circleci/config.yml#L334

Aside from adding the "latest-upstream" alias,  this PR has

 * A few minor cleanups in the emsdk code.
 * Minor restructuring of how we define the upstream stuff in the manifest: It seemed odd to have 3 things (clang, emscripten, binaryen) that are all coming from a single archive from the waterfall. Simpler to have just one - the archive is one big lump, there's no way to download just part of it.
 * Also add node 8.9.1 as a dependency of the upstream sdk, which makes things usable out of the box (node.js is the one thing not provided by the waterfall archive).
