### PR TITLE
Deduplicate activated configs in the .emscripten file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,7 @@ RUN cd /root/ \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -s WASM_OBJECT_FILES=1
+ && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 \
+ && python -c "import os ; assert open(os.path.expanduser('~/.emscripten')).read().count('LLVM_ROOT') == 1" \
+ && python -c "import os ; assert 'upstream' in open(os.path.expanduser('~/.emscripten')).read()"
 

--- a/emsdk
+++ b/emsdk
@@ -1052,13 +1052,26 @@ def generate_dot_emscripten(active_tools):
   if embedded:
     cfg += "emsdk_path=os.path.dirname(os.environ.get('EM_CONFIG')).replace('\\\\', '/')\n"
 
+  # Different tools may provide the same activated configs; the latest to be
+  # activated is the relevant one.
+  final_activated_names = []
+  final_activated_values = {}
+
   for tool in active_tools:
     tool_cfg = tool.activated_config()
     if tool_cfg:
-      tool_cfg = tool_cfg.replace(';', '\n')
-      if 'SPIDERMONKEY_ENGINE=' in tool_cfg: has_spidermonkey = True
-      if 'NODE_JS=' in tool_cfg: has_node = True
-      cfg += tool_cfg + '\n'
+      for specific_cfg in tool_cfg.split(';'):
+        name, value = specific_cfg.split('=')
+        if name not in final_activated_values:
+          final_activated_names.append(name)
+        final_activated_values[name] = value
+
+  for name in final_activated_names:
+    if name == 'SPIDERMONKEY_ENGINE':
+      has_spidermonkey = True
+    if name == 'NODE_JS':
+      has_node = True
+    cfg += name + ' = ' + final_activated_values[name] + '\n'
 
   # These two vars must always be defined, even though they might not exist.
   if not has_spidermonkey: cfg += "SPIDERMONKEY_ENGINE = ''\n"


### PR DESCRIPTION
While doing so, we:

* keep the latest activation (e.g., the user may have activated `latest` and then `latest-upstream`, then the upstream LLVM is what is desired).
* keep the order of keys fixed (so the relative order of lines in the `.emscripten` file is fixed)

This adds some assertions in the Dockerfile, to verify we have one `LLVM_ROOT` command, and it is the right one. Probably we should put tests in a nicer place (file, directory) - where would you prefer?

Fixes #194

cc @juj @jgravelle-google 