### PR TITLE
Avoid a Docker warning on an unused build arg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 script:
   - set -o errexit
   - echo "running..."
-  - docker build --build-arg TEST_TARGET="$TEST_TARGET" .
+  - docker build .
 
 notifications:
   email: false


### PR DESCRIPTION
(which was there just from some old copy-paste, I think)