### PR TITLE
Re-land #200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,19 @@ RUN cd /root/ \
  && emcc hello_world.cpp -s WASM=0 -o d.out.js \
  && echo "text executions" \
  && /root/emsdk/node/8.9.1_64bit/bin/node a.out.js &> o \
+ && ls -al o \
  && cat o \
+ && echo \
  && /root/emsdk/node/8.9.1_64bit/bin/node b.out.js &> o \
+ && ls -al o \
  && cat o \
+ && echo \
  && /root/emsdk/node/8.9.1_64bit/bin/node c.out.js &> o \
+ && ls -al o \
  && cat o \
+ && echo \
  && /root/emsdk/node/8.9.1_64bit/bin/node d.out.js &> o \
- && cat o
+ && ls -al o \
+ && cat o \
+ && echo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,20 +14,21 @@ RUN cd /root/ \
  && /root/emsdk/emsdk install latest \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
- && node/8.9.1_64bit/bin/node a.out.js \
+ && emcc hello_world.cpp -o a.out.js \
  && echo "test upstream (waterfall)" \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 \
- && node/8.9.1_64bit/bin/node a.out.js \
+ && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 -o b.out.js \
  && echo "test fastcomp (waterfall)" \
  && /root/emsdk/emsdk install latest-fastcomp \
  && /root/emsdk/emsdk activate latest-fastcomp \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp \
+ && emcc hello_world.cpp -o c.out.js \
+ && emcc hello_world.cpp -s WASM=0 -o d.out.js \
+ && echo "text executions" \
  && node/8.9.1_64bit/bin/node a.out.js \
- && emcc hello_world.cpp -s WASM=0 \
- && node/8.9.1_64bit/bin/node a.out.js
+ && node/8.9.1_64bit/bin/node b.out.js \
+ && node/8.9.1_64bit/bin/node c.out.js \
+ && node/8.9.1_64bit/bin/node d.out.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,33 +14,16 @@ RUN cd /root/ \
  && /root/emsdk/emsdk install latest \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -o a.out.js \
+ && emcc hello_world.cpp \
  && echo "test upstream (waterfall)" \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 -o b.out.js \
+ && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 \
  && echo "test fastcomp (waterfall)" \
  && /root/emsdk/emsdk install latest-fastcomp \
  && /root/emsdk/emsdk activate latest-fastcomp \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -o c.out.js \
- && emcc hello_world.cpp -s WASM=0 -o d.out.js \
- && echo "text executions" \
- && /root/emsdk/node/8.9.1_64bit/bin/node a.out.js &> o \
- && ls -al o \
- && cat o \
- && echo \
- && /root/emsdk/node/8.9.1_64bit/bin/node b.out.js &> o \
- && ls -al o \
- && cat o \
- && echo \
- && /root/emsdk/node/8.9.1_64bit/bin/node c.out.js &> o \
- && ls -al o \
- && cat o \
- && echo \
- && /root/emsdk/node/8.9.1_64bit/bin/node d.out.js &> o \
- && ls -al o \
- && cat o \
- && echo
+ && emcc hello_world.cpp \
+ && emcc hello_world.cpp -s WASM=0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,19 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && nodejs a.out.js \
+ && node a.out.js \
  && echo "test upstream (waterfall)" \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 \
- && nodejs a.out.js \
+ && node a.out.js \
  && echo "test fastcomp (waterfall)" \
  && /root/emsdk/emsdk install latest-fastcomp \
  && /root/emsdk/emsdk activate latest-fastcomp \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && nodejs a.out.js \
+ && node a.out.js \
  && emcc hello_world.cpp -s WASM=0 \
- && nodejs a.out.js
+ && node a.out.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,12 @@ RUN cd /root/ \
  && emcc hello_world.cpp -o c.out.js \
  && emcc hello_world.cpp -s WASM=0 -o d.out.js \
  && echo "text executions" \
- && /root/emsdk/node/8.9.1_64bit/bin/node a.out.js \
- && /root/emsdk/node/8.9.1_64bit/bin/node b.out.js \
- && /root/emsdk/node/8.9.1_64bit/bin/node c.out.js \
- && /root/emsdk/node/8.9.1_64bit/bin/node d.out.js
+ && /root/emsdk/node/8.9.1_64bit/bin/node a.out.js &> o \
+ && cat o \
+ && /root/emsdk/node/8.9.1_64bit/bin/node b.out.js &> o \
+ && cat o \
+ && /root/emsdk/node/8.9.1_64bit/bin/node c.out.js &> o \
+ && cat o \
+ && /root/emsdk/node/8.9.1_64bit/bin/node d.out.js &> o \
+ && cat o
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,19 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && node a.out.js \
+ && node/8.9.1_64bit/bin/node a.out.js \
  && echo "test upstream (waterfall)" \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 \
- && node a.out.js \
+ && node/8.9.1_64bit/bin/node a.out.js \
  && echo "test fastcomp (waterfall)" \
  && /root/emsdk/emsdk install latest-fastcomp \
  && /root/emsdk/emsdk activate latest-fastcomp \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && node a.out.js \
+ && node/8.9.1_64bit/bin/node a.out.js \
  && emcc hello_world.cpp -s WASM=0 \
- && node a.out.js
+ && node/8.9.1_64bit/bin/node a.out.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,25 @@ RUN cd /root/ \
  && echo "int main() {}" > hello_world.cpp \
  && apt-get update \
  && apt-get install -y python cmake build-essential openjdk-9-jre-headless \
+ && /root/emsdk/emsdk update-tags \
+ && echo "test latest" \
  && /root/emsdk/emsdk install latest \
  && /root/emsdk/emsdk activate latest \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && /root/emsdk/emsdk update-tags \
+ && nodejs a.out.js \
+ && echo "test upstream (waterfall)" \
  && /root/emsdk/emsdk install latest-upstream \
  && /root/emsdk/emsdk activate latest-upstream \
  && source /root/emsdk/emsdk_env.sh --build=Release \
- && emcc hello_world.cpp -s WASM_OBJECT_FILES=1
+ && emcc hello_world.cpp -s WASM_OBJECT_FILES=1 \
+ && nodejs a.out.js \
+ && echo "test fastcomp (waterfall)" \
+ && /root/emsdk/emsdk install latest-fastcomp \
+ && /root/emsdk/emsdk activate latest-fastcomp \
+ && source /root/emsdk/emsdk_env.sh --build=Release \
+ && emcc hello_world.cpp \
+ && nodejs a.out.js \
+ && emcc hello_world.cpp -s WASM=0 \
+ && nodejs a.out.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN cd /root/ \
  && emcc hello_world.cpp -o c.out.js \
  && emcc hello_world.cpp -s WASM=0 -o d.out.js \
  && echo "text executions" \
- && node/8.9.1_64bit/bin/node a.out.js \
- && node/8.9.1_64bit/bin/node b.out.js \
- && node/8.9.1_64bit/bin/node c.out.js \
- && node/8.9.1_64bit/bin/node d.out.js
+ && /root/emsdk/node/8.9.1_64bit/bin/node a.out.js \
+ && /root/emsdk/node/8.9.1_64bit/bin/node b.out.js \
+ && /root/emsdk/node/8.9.1_64bit/bin/node c.out.js \
+ && /root/emsdk/node/8.9.1_64bit/bin/node d.out.js
 

--- a/emsdk
+++ b/emsdk
@@ -1527,12 +1527,18 @@ def find_latest_nightly_sdk():
   else:
     return find_latest_nightly_32bit_sdk()
 
-def find_latest_upstream_sdk():
+def find_latest_waterfall_sdk(which):
   waterfall_lkgr = load_waterfall_lkgr()
   if not waterfall_lkgr:
     print('Failed to find an upstream lkgr')
     sys.exit(1)
-  return 'sdk-upstream-%s-64bit' % waterfall_lkgr[0]
+  return 'sdk-%s-%s-64bit' % (which, waterfall_lkgr[0])
+
+def find_latest_upstream_sdk():
+  return find_latest_waterfall_sdk('upstream')
+
+def find_latest_fastcomp_sdk():
+  return find_latest_waterfall_sdk('fastcomp')
 
 # Finds the best-matching python tool for use.
 def find_used_python():
@@ -2225,6 +2231,8 @@ def main():
         sys.argv[i] = str(find_latest_nightly_64bit_sdk())
       elif sys.argv[i] == 'latest-upstream' or sys.argv[i] == 'latest-clang-upstream':
         sys.argv[i] = str(find_latest_upstream_sdk())
+      elif sys.argv[i] == 'latest-fastcomp':
+        sys.argv[i] = str(find_latest_fastcomp_sdk())
 
   if cmd == 'list':
     print('')

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -1563,7 +1563,7 @@
     "bitness": 64,
     "uses": ["waterfall-fastcomp-%waterfall-lkgr%-64bit", "node-8.9.1-64bit"],
     "os": "linux"
-  }
+  },
   {
     "version": "%precompiled_tag32%",
     "bitness": 32,

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -200,6 +200,15 @@
     "activated_cfg": "LLVM_ROOT='%installation_dir%/bin';BINARYEN_ROOT='%installation_dir%'"
   },
   {
+    "id": "waterfall",
+    "version": "fastcomp-%waterfall-lkgr%",
+    "bitness": 64,
+    "linux_url": "https://storage.googleapis.com/wasm-llvm/builds/linux/%waterfall-lkgr%/wasm-binaries.tbz2",
+    "install_path": "fastcomp/%waterfall-lkgr%",
+    "activated_path": "%installation_dir%/emscripten",
+    "activated_cfg": "LLVM_ROOT='%installation_dir%/fastcomp/bin';BINARYEN_ROOT='%installation_dir%'"
+  },
+  {
     "id": "clang",
     "version": "e1.13.0",
     "bitness": 64,
@@ -1549,6 +1558,12 @@
     "uses": ["waterfall-upstream-%waterfall-lkgr%-64bit", "node-8.9.1-64bit"],
     "os": "linux"
   },
+  {
+    "version": "fastcomp-%waterfall-lkgr%",
+    "bitness": 64,
+    "uses": ["waterfall-fastcomp-%waterfall-lkgr%-64bit", "node-8.9.1-64bit"],
+    "os": "linux"
+  }
   {
     "version": "%precompiled_tag32%",
     "bitness": 32,


### PR DESCRIPTION
(This was reverted by mistake. It had a bad commit message though, so relanding with a nicer one is nice anyhow.)

With this, we can do emsdk install latest-fastcomp and it installs fastcomp from the waterfall. That is, we then have 3 main sdks people might want to use:

* latest which installs fastcomp-llvm (plus emscripten etc.) from the mozilla infrastructure. (fetches the last emscripten version there)
* latest-upstream which installs upstream-llvm (plus emscripten etc.) from the waterfall infrastructure. (fetches the last known good revision (lkgr) there)
* latest-fastcomp which installs fastcomp-llvm (plus emscripten etc.) from the waterfall infrastructure. (fetches the last known good revision (lkgr) there)

The first and last are currently somewhat overlapping in that both fetch a build of fastcomp. However, as we transition away from the mozilla infrastructure, we could just make latest an alias for latest-fastcomp. (And later, when we're ready to switch to the wasm backend by default, the alias could switch to latest-upstream.)