### PR TITLE
Remove wasm.js reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,7 @@ RUN cd /root/ \
  && /root/emsdk/emsdk activate latest-fastcomp \
  && source /root/emsdk/emsdk_env.sh --build=Release \
  && emcc hello_world.cpp \
- && emcc hello_world.cpp -s WASM=0
+ && emcc hello_world.cpp -s WASM=0 \
+ && echo "test binaryen source build" \
+ && /root/emsdk/emsdk install --build=Release binaryen-master-64bit
 

--- a/emsdk
+++ b/emsdk
@@ -968,7 +968,6 @@ def build_binaryen_tool(tool):
   shutil.copytree(os.path.join(src_root, 'scripts'), os.path.join(build_root, 'scripts'))
   remove_tree(os.path.join(build_root, 'src', 'js'))
   shutil.copytree(os.path.join(src_root, 'src', 'js'), os.path.join(build_root, 'src', 'js'))
-  shutil.copyfile(os.path.join(src_root, 'bin', 'wasm.js'), os.path.join(build_root, 'bin', 'wasm.js'))
 
   return success
 


### PR DESCRIPTION
We removed it in Binaryen #1858. The reference here broke source installs using the emsdk.

Fixes https://github.com/juj/emsdk/issues/206